### PR TITLE
Call Spinnaker::System::ReleaseInstance only when no camera is in use

### DIFF
--- a/spinnaker_camera_driver/src/SpinnakerCamera.cpp
+++ b/spinnaker_camera_driver/src/SpinnakerCamera.cpp
@@ -69,7 +69,7 @@ SpinnakerCamera::SpinnakerCamera()
 SpinnakerCamera::~SpinnakerCamera()
 {
   camList_.Clear();
-  system_->ReleaseInstance();
+  if (!system_->IsInUse()) system_->ReleaseInstance();
 }
 
 void SpinnakerCamera::setNewConfiguration(spinnaker_camera_driver::SpinnakerConfig& config, const uint32_t& level)


### PR DESCRIPTION
which fixes exception on nodelet shutdown when using with multiple cameras in one nodelet process.