### PR TITLE
get image time stamp before image decompress function

### DIFF
--- a/spinnaker_camera_driver/src/SpinnakerCamera.cpp
+++ b/spinnaker_camera_driver/src/SpinnakerCamera.cpp
@@ -413,11 +413,6 @@ void SpinnakerCamera::grabImage(sensor_msgs::Image* image, const std::string& fr
         throw IncompleteImageException(oss.str());
       }
 
-      if (image_ptr->IsCompressed())
-      {
-        image_ptr = image_ptr->Convert(image_ptr->GetPixelFormat(), Spinnaker::DEFAULT);
-      }
-
       // Set Image Time Stamp
       if (use_device_seq_) image->header.seq = static_cast<uint32_t>(image_ptr->GetID());
       else                 image->header.seq = seq_++;
@@ -425,6 +420,11 @@ void SpinnakerCamera::grabImage(sensor_msgs::Image* image, const std::string& fr
       ros::Time img_time = ros::Time();
       img_time.fromNSec(static_cast<uint64_t>(image_ptr->GetTimeStamp()));
       image->header.stamp = img_time + timestamp_diff;
+
+      if (image_ptr->IsCompressed())
+      {
+        image_ptr = image_ptr->Convert(image_ptr->GetPixelFormat(), Spinnaker::DEFAULT);
+      }
 
       // Check the bits per pixel.
       size_t bitsPerPixel = image_ptr->GetBitsPerPixel();


### PR DESCRIPTION
to avoid error using both `use_device_timestamp` and `image_compression_mode`.
`GetTimeStamp` could not get timestamp properly after `Convert`.